### PR TITLE
Expose HTTP status and retry_after on command errors

### DIFF
--- a/src/main/java/com/payneteasy/telegram/bot/client/TelegramCommandException.java
+++ b/src/main/java/com/payneteasy/telegram/bot/client/TelegramCommandException.java
@@ -4,17 +4,24 @@ public class TelegramCommandException extends RuntimeException {
 
     private final String  id;
     private final Integer errorCode;
+    private final Integer retryAfter;
 
     public TelegramCommandException(String message, String id, Integer code) {
+        this(message, id, code, null);
+    }
+
+    public TelegramCommandException(String message, String id, Integer code, Integer retryAfter) {
         super(message);
         this.id = id;
         this.errorCode = code;
+        this.retryAfter = retryAfter;
     }
 
     public TelegramCommandException(String message, Throwable cause, String id, Integer code) {
         super(message, cause);
         this.id = id;
         this.errorCode = code;
+        this.retryAfter = null;
     }
 
     public String getId() {
@@ -23,5 +30,12 @@ public class TelegramCommandException extends RuntimeException {
 
     public Integer getErrorCode() {
         return errorCode;
+    }
+
+    /**
+     * @return seconds to wait before retrying (from Telegram's parameters.retry_after on 429), or null.
+     */
+    public Integer getRetryAfter() {
+        return retryAfter;
     }
 }

--- a/src/main/java/com/payneteasy/telegram/bot/client/http/TelegramHttpClientImpl.java
+++ b/src/main/java/com/payneteasy/telegram/bot/client/http/TelegramHttpClientImpl.java
@@ -58,6 +58,18 @@ public class TelegramHttpClientImpl implements ITelegramHttpClient {
         return String.valueOf(commandId.incrementAndGet());
     }
 
+    private Integer parseRetryAfter(String responseJson) {
+        try {
+            TelegramStandardResponse error = gson.fromJson(responseJson, TelegramStandardResponse.class);
+            if (error != null && error.getParameters() != null) {
+                return error.getParameters().getRetryAfter();
+            }
+        } catch (Exception e) {
+            LOG.debug("Cannot parse error body for retry_after: {}", responseJson);
+        }
+        return null;
+    }
+
     @Override
     public <R, T> T post(String aMethodName, R aRequest, Class<T> aResponseClass) {
         String id = nextCommandId();
@@ -76,7 +88,7 @@ public class TelegramHttpClientImpl implements ITelegramHttpClient {
                 String             responseJson     = new String(response.getBody(), UTF_8);
                 LOG.debug("{} {}: response {}", id, aMethodName, responseJson);
                 if (response.getStatusCode() != 200) {
-                    throw new TelegramCommandException(responseJson, id, -2);
+                    throw new TelegramCommandException(responseJson, id, response.getStatusCode(), parseRetryAfter(responseJson));
                 }
                 return gson.fromJson(responseJson, aResponseClass);
             }

--- a/src/main/java/com/payneteasy/telegram/bot/client/messages/TelegramStandardResponse.java
+++ b/src/main/java/com/payneteasy/telegram/bot/client/messages/TelegramStandardResponse.java
@@ -1,6 +1,7 @@
 package com.payneteasy.telegram.bot.client.messages;
 
 import com.google.gson.annotations.SerializedName;
+import com.payneteasy.telegram.bot.client.model.ResponseParameters;
 import lombok.Data;
 
 @Data
@@ -25,5 +26,10 @@ public class TelegramStandardResponse {
      */
     @SerializedName("error_code")
     private final Integer errorCode;
+
+    /**
+     * Optional field returned on some errors (e.g. 'retry_after' on 429 Too Many Requests).
+     */
+    private ResponseParameters parameters;
 
 }

--- a/src/main/java/com/payneteasy/telegram/bot/client/model/ResponseParameters.java
+++ b/src/main/java/com/payneteasy/telegram/bot/client/model/ResponseParameters.java
@@ -1,0 +1,20 @@
+package com.payneteasy.telegram.bot.client.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+/**
+ * Optional 'parameters' field returned by Telegram on some errors, used to automatically handle them.
+ */
+@Data
+public class ResponseParameters {
+
+    /**
+     * The number of seconds left to wait before the request can be repeated (present on 429 Too Many Requests).
+     */
+    @SerializedName("retry_after")
+    private Integer retryAfter;
+
+    @SerializedName("migrate_to_chat_id")
+    private Long migrateToChatId;
+}


### PR DESCRIPTION
## What

Expose the real HTTP status code and Telegram's `retry_after` on errors, so callers can honor rate limits (HTTP 429 Too Many Requests) instead of guessing.

- `TelegramHttpClientImpl.post(...)`: on a non-200 response, throw `TelegramCommandException` with the **actual HTTP status code** (was hard-coded `-2`) and the parsed `parameters.retry_after`.
- `TelegramCommandException`: add `Integer retryAfter` + `getRetryAfter()` and a constructor carrying it (existing constructors kept — additive/backward-compatible).
- `TelegramStandardResponse`: add optional `parameters` field.
- New `model/ResponseParameters` (`retry_after`, `migrate_to_chat_id`).

## Why

A consumer (deploy server) is adding a rate-limited Telegram send queue and needs to back off for exactly `retry_after` seconds on 429. Today the library collapses every non-200 into `errorCode = -2` with only the raw JSON in the message, so the status and `retry_after` are not accessible programmatically.

## Notes

- Backward compatible: no method signatures removed; new field/constructor only.
- Needs to be released as **1.0-10** for the consumer to depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
